### PR TITLE
Mqtt support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/eclipse/paho.mqtt.golang v1.4.3 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -26,6 +27,7 @@ require (
 	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
@@ -43,6 +45,7 @@ require (
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
+github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gin-contrib/pprof v1.4.0 h1:XxiBSf5jWZ5i16lNOPbMTVdgHBdhfGRD5PZ1LWazzvg=
@@ -49,6 +51,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/headzoo/surf v1.0.1 h1:wk3+LT8gjnCxEwfBJl6MhaNg154En5KjgmgzAG9uMS0=
 github.com/headzoo/surf v1.0.1/go.mod h1:/bct0m/iMNEqpn520y01yoaWxsAEigGFPnvyR1ewR5M=
 github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca h1:utFgFwgxaqx5OthzE3DSGrtOq7rox5r2sxZ2wbfTuK0=
@@ -140,6 +144,8 @@ golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ var options struct {
 	Loglevel        string `long:"loglevel" default:"warn" description:"logLevel (trace,debug,info,warn(ing),error,fatal,panic)"`
 	Mode            string `long:"mode" default:"webscraping" description:"Gathering mode (webscraping|modbus)"`
 	ModbusSlaveId   int64  `long:"modbusSlaveId" default:"1" description:"slaveId to use for modbus communication"`
+	MqttHost        string `long:"mqttHost" description:"MQTT host to send data to (optional)"`
+	MqttPort        int64  `long:"mqttPort" description:"MQTT port to send data to (optional)" default:"1883"`
+	MqttTopicPrefix string `long:"mqttTopicPrefix" description:"Topic prefix for MQTT" default:"isg"`
 	// TODO: SkipCooling  bool   `long:"skipCooling" description:"Toggle to skip data for cooling" env:"SKIP_COOLING"`
 }
 
@@ -154,6 +157,9 @@ func prepare() {
 	case MODE_WEBSCRAPING:
 		prepareScraping()
 	}
+	if len(options.MqttHost) > 0 {
+		connectMqtt()
+	}
 }
 
 func gatherData() {
@@ -165,6 +171,9 @@ func gatherData() {
 		gatherModbusData()
 	case MODE_WEBSCRAPING:
 		gatherScrapingData()
+	}
+	if len(options.MqttHost) > 0 {
+		publishMqtt()
 	}
 }
 

--- a/mqtt.go
+++ b/mqtt.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	json "encoding/json"
+	"fmt"
+	"strings"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	log "github.com/sirupsen/logrus"
+)
+
+var mqttClient mqtt.Client
+
+var connectHandler mqtt.OnConnectHandler = func(client mqtt.Client) {
+	log.Info("MQTT connected")
+}
+
+var connectionLostHandler mqtt.ConnectionLostHandler = func(client mqtt.Client, err error) {
+	log.Warnf("MQTT connection lost: %v", err)
+}
+
+func connectMqtt() {
+	clientOptions := mqtt.NewClientOptions()
+	clientOptions.AddBroker(fmt.Sprintf("tcp://%s:%d", options.MqttHost, options.MqttPort))
+	clientOptions.SetOnConnectHandler(connectHandler)
+	clientOptions.SetConnectionLostHandler(connectionLostHandler)
+	mqttClient = mqtt.NewClient(clientOptions)
+	if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		log.Errorf("Connect to MQTT failed: %s", token.Error())
+	}
+}
+
+func publishMqtt() {
+	for name, value := range valuesMap {
+		topic := options.MqttTopicPrefix + "/" + strings.Replace(strings.ToLower(name), ".", "/", -1)
+		content, _ := json.Marshal(value)
+
+		log.Debugf("publishing %s to %s", content, topic)
+		mqttClient.Publish(topic, 0, false, content)
+	}
+}


### PR DESCRIPTION
Add basic MQTT support. 

Allows to have all metrics pushed to a MQTT broker with a configurable prefix. Will allow future enhancement with write support (e.g. using MQTT to change the fan speed, target temperature, ...)
No authn/authz or TLS support so far.