### PR TITLE
Support non-unique metric names by optional prefixing with section names

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,26 @@ Usage:
   isg_exporter [OPTIONS]
 
 Application Options:
-      --port=            The address to listen on for HTTP requests. (default: 8080) [$EXPORTER_PORT]
-      --interval=        The frequency in seconds in which to gather data (default: 60) [$INTERVAL]
-      --url=             URL for ISG [$ISG_URL]
-      --user=            username for ISG [$ISG_USER]
-      --password=        password for ISG [$ISG_PASSWORD]
-      --browserRollover= number of iterations until the internal browser is recreated (default: 60)
-      --skipCircuit2     Toogle to skip data for circuit 2 [$SKIP_CIRCUIT_2]
+      --port=                     The address to listen on for HTTP requests. (default: 8080) [$EXPORTER_PORT]
+      --interval=                 The frequency in seconds in which to gather data (default: 60) [$INTERVAL]
+      --url=                      URL for ISG [$ISG_URL]
+      --user=                     username for ISG [$ISG_USER]
+      --password=                 password for ISG [$ISG_PASSWORD]
+      --browserRollover=          number of iterations until the internal browser is recreated (default: 60)
+      --skipCircuit2              Toogle to skip data for circuit 2 [$SKIP_CIRCUIT_2]
       --debug
-      --loglevel=        logLevel (trace,debug,info,warn(ing),error,fatal,panic) (default: warn)
-      --mode=            Gathering mode (webscraping|modbus) (default: webscraping)
-      --modbusSlaveId=   slaveId to use for modbus communication (default: 1)
+      --loglevel=                 logLevel (trace,debug,info,warn(ing),error,fatal,panic) (default: warn)
+      --mode=                     Gathering mode (webscraping|modbus) (default: webscraping)
+      --modbusSlaveId=            slaveId to use for modbus communication (default: 1)
+      --mqttHost=                 MQTT host to send data to (optional)
+      --mqttPort=                 MQTT port to send data to (optional) (default: 1883)
+      --mqttTls                   Activate TLS for MQTT
+      --mqttTlsInsecure           Allow insecure TLS for MQTT
+      --mqttTopicPrefix=          Topic prefix for MQTT (default: isg)
+      --mqttDiscoveryTopicPrefix= Topic prefix for homeassistant discovery (default: homeassistant)
+      --mqttUser=                 Username to use for the MQTT connection [$MQTT_USER]
+      --mqttPassword=             Password to use for the MQTT connection [$MQTT_PASSWORD]
+      --metricsSectionPrefix      Prefix metrics with their section identifier in webscraping mode [$METRICS_SECTION_PREFIX]
 
 Help Options:
   -h, --help             Show this help message
@@ -60,6 +69,10 @@ Examples:
 
 Metrics for circuit 2 can be skipped (e.g. when not in use to reduce number of metrics) by providing `--skipCircuit2` on the command line.
 
+Some ISG do have non-unique names for their metrics in webscraping mode. It is configurable if the section names should be provided in front.
+This was made configurable to not break existing configurations (e.g. Grafana dashboards), because this was only noted later.
+Always adding the section prefix can be configured using the flag `--metricsWithSectionPrefix`. The default is to not use the prefix.
+
 For the modbus mode, metric names are based on explicitly defined names in a configuration file. A [default config](modbus-mapping.yaml) is packaged in the Docker image.
 
 ## RESTFul status
@@ -87,6 +100,7 @@ If the alert status is `resolved`, SGReady status is set back to status 2 (norma
 With this, you are free to define an arbitrary alert in Prometheus (e.g. when your power grid feed is > 3kW) which, when triggered, causes your heat pump to get active. When the alerts is lifted it will return.
 Within Alertmanager, you can register isg-exporter as a receiver to only receive these alerts.
 The URL endpoint for alertmanager webhooks is `/webhooks/alertmanager`.
+This is available only in modbus mode, setting the SGReady status is not (yet?) implemented for webscraping mode.
 
 There are additional prometheus metrics with counters for the amount of activations per level and the amount of errors encountered.
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var options struct {
 	MqttDiscoveryTopicPrefix string `long:"mqttDiscoveryTopicPrefix" description:"Topic prefix for homeassistant discovery" default:"homeassistant"`
 	MqttUser                 string `long:"mqttUser" description:"Username to use for the MQTT connection" env:"MQTT_USER"`
 	MqttPassword             string `long:"mqttPassword" description:"Password to use for the MQTT connection" env:"MQTT_PASSWORD"`
+	MetricsWithSectionPrefix bool   `long:"metricsWithSectionPrefix" description:"Prefix metrics with their section identifier in webscraping mode" env:"METRICS_WITH_SECTION_PREFIX"`
 	// TODO: SkipCooling  bool   `long:"skipCooling" description:"Toggle to skip data for cooling" env:"SKIP_COOLING"`
 }
 

--- a/scraping_test.go
+++ b/scraping_test.go
@@ -170,6 +170,6 @@ func TestPage(t *testing.T) {
 		t.Errorf("Failed to find expected onoff value")
 	}
 
-	json, _ := json.Marshal(valuesMap)
+	json, _ := json.MarshalIndent(valuesMap, "", "  ")
 	fmt.Println(string(json))
 }


### PR DESCRIPTION
This PR adds support for non-unique metrics names which overwrote themselves previously if different pages contained the same field names / keys in different sections (as reported in #66). 

With this MR, the metrics can be prefixed with their section names (still leaving room for identical section names and keys on different pages). To not break existing installations and to keep the metric names (not all systems have duplicates), this is governed by a config switch. The default is like it was previously, prefixing must be explicitly enabled. 

Kudos to @svenoone for providing an initial fix in #68, which was the basis for this PR. 

fixes #66 